### PR TITLE
Allow exporting vmlinux debuginfo

### DIFF
--- a/src/dwarfexport.cpp
+++ b/src/dwarfexport.cpp
@@ -740,7 +740,8 @@ void add_debug_info(std::shared_ptr<DwarfGenInfo> info,
       f = get_next_func(seg->startEA);
 
       if (f == nullptr) {
-        dwarfexport_error("get_next_func() failed");
+        dwarfexport_log("Skipping ", lsegname, " because it has no functions");
+        continue;
       }
     }
 

--- a/src/dwarfexport.cpp
+++ b/src/dwarfexport.cpp
@@ -724,7 +724,7 @@ void add_debug_info(std::shared_ptr<DwarfGenInfo> info,
 
     // Only consider EXEC segments
     // TODO: Skip plt/got?
-    if (!(seg->perm & SEGPERM_EXEC)) {
+    if (!(seg->perm & SEGPERM_EXEC) && seg->type != SEG_CODE) {
       dwarfexport_log("Segment #", segn, " is not executable. Skipping.");
       continue;
     }


### PR DESCRIPTION
This PR makes the following improvements in order to make it possible to export vmlinux debuginfo:

* Do not skip segments with type SEG_CODE, even if they do not have SEGPERM_EXEC.
* Do not fail on segments which don't have any functions.
* Tolerate overlapping sections.