### PR TITLE
Add return to run()

### DIFF
--- a/src/dwarfexport.cpp
+++ b/src/dwarfexport.cpp
@@ -837,6 +837,7 @@ void idaapi run(int) {
   } catch (...) {
     warning("A dwarfexport error occurred");
   }
+  return true;
 }
 
 plugin_t PLUGIN = {


### PR DESCRIPTION
Missing return is an UB.